### PR TITLE
fix: compatibility for django>=1.6

### DIFF
--- a/topnotchdev/files_widget/urls.py
+++ b/topnotchdev/files_widget/urls.py
@@ -1,7 +1,8 @@
-if float("%d.%d"%(django.VERSION[0],django.VERSION[1])) <= 1.5:
-    from django.conf.urls.defaults import patterns,url
-else:    
-    from django.conf.urls import patterns,url
+import django
+if float("%d.%d" % (django.VERSION[0], django.VERSION[1])) <= 1.5:
+    from django.conf.urls.defaults import patterns, url
+else:
+    from django.conf.urls import patterns, url
 
 from django.conf import settings
 


### PR DESCRIPTION
bug: if on django 1.6, an exception will raised:
      ImportError: No module named defaults
