### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Quick Start
     
     MEDIA_URL = ...
     MEDIA_ROOT = ...
-
+    THUMBNAIL_DEBUG = False
+    
 (Optional) basic settings with their defaults:
 
     FILES_WIDGET_TEMP_DIR            # 'temp/files_widget/'
@@ -72,8 +73,7 @@ Quick Start
     FILES_WIDGET_JQUERY_UI_PATH      # (jQuery UI 1.10.3 from Google)
     FILES_WIDGET_USE_FILEBROWSER     # False
     FILES_WIDGET_FILEBROWSER_JS_PATH # 'filebrowser/js/AddFileBrowser.js'
-    THUMBNAIL_DEBUG                  # False
-
+    
 ### In `urls.py` ###
 
     url(r'^files-widget/', include('topnotchdev.files_widget.urls')),


### PR DESCRIPTION
Sorl Thumnail currently requires THUMBNAIL_DEBUG = False

Hi as of the time of writing, the version of sorl-thumbnail installed, 11.12.1b, has a requirement that THUMBNAIL_DEBUG = False otherwise it fails when there are errors, and it's quite hard to debug on a remote server.

I have just added a document patch so others don't have the issue.

This pull request to sorl-thumbnail gave me the clue and enabled me to work round the problem:
https://github.com/mariocesar/sorl-thumbnail/pull/261
